### PR TITLE
(mitchs-dev/worklog#1): Add pre-parsing year/week creation

### DIFF
--- a/internal/logManager/helpers.go
+++ b/internal/logManager/helpers.go
@@ -1,0 +1,60 @@
+package logManager
+
+import (
+	"encoding/json"
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/mitchs-dev/library-go/processor"
+	"github.com/mitchs-dev/worklog/internal/calendarManager"
+)
+
+// CreateYearIfNotExist creates a year and week if it does not exist
+func CreateWeekIfNotExist(logFilePath string) {
+
+	log.Debug("Using log file path: ", logFilePath)
+
+	// Get the year from the end of the filename.Dir
+	basePath := filepath.Dir(logFilePath)
+
+	log.Debug("basePath: ", basePath)
+
+	// Get the week from the end of the filename
+	weekFile := filepath.Base(logFilePath)
+
+	log.Debug("weekFile: ", weekFile)
+
+	// Check if the year exists
+	if !processor.DirectoryOrFileExists(basePath) {
+
+		// Create the year
+		if !processor.CreateDirectory(basePath) {
+			log.Fatalf("Failed to create basePath %v", basePath)
+		}
+	} else {
+		log.Debugf("basePath %v already exists", basePath)
+	}
+
+	// Check if the week exists
+	if processor.DirectoryOrFileExists(logFilePath) {
+		log.Debugf("logFilePath %v already exists", logFilePath)
+		return
+	} else {
+		// Create the empty week
+		emptyWeek := calendarManager.WeekTree{Weeks: make(map[int]calendarManager.MonthDayTree)}
+
+		// Marshal the empty week
+		emptyWeekData, err := json.Marshal(emptyWeek)
+		if err != nil {
+			log.Fatal("Error creating week (", logFilePath, "): ", err)
+		}
+
+		// Create the week
+		if !processor.CreateFileAsByte(logFilePath, emptyWeekData) {
+			log.Fatal("Error creating week (", logFilePath, ")")
+		} else {
+			log.Debugf("Created week %v", logFilePath)
+		}
+	}
+}

--- a/internal/logManager/parser.go
+++ b/internal/logManager/parser.go
@@ -15,6 +15,9 @@ import (
 // GetLogFile opens the log file and returns the contents
 func (l *LogFile) GetLogFile(logFilePath string) error {
 
+	// Check if the log file exists
+	CreateWeekIfNotExist(logFilePath)
+
 	log.Debug("Opening log file: " + logFilePath)
 
 	// Open the log file


### PR DESCRIPTION
This pull request includes changes to the `internal/logManager` package, focusing on adding functionality to ensure the existence of log files and directories before accessing them. The most important changes include adding a new helper function and updating the log file parser to use this new function.

### Enhancements to log file management:

* [`internal/logManager/helpers.go`](diffhunk://#diff-e50d1e6ee3f3466649d257a614d7aaffea5b71bd2a21b093770031c7a9dded74R1-R60): Added a new function `CreateWeekIfNotExist` that checks for the existence of a year and week directory, creates them if they do not exist, and initializes an empty week file.
* [`internal/logManager/parser.go`](diffhunk://#diff-f3d38cafc8ec9f0055295ae294b2f0103a842a299084974d852064d16a264082R18-R20): Updated the `GetLogFile` method to call `CreateWeekIfNotExist` before attempting to open the log file, ensuring that the necessary directories and files are present.